### PR TITLE
fix usage of cp in install scripts

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.json
+++ b/org.freedesktop.Sdk.Extension.openjdk8.json
@@ -166,7 +166,7 @@
                     "commands": [
                         "mkdir -p /app/jre",
                         "cd /usr/lib/sdk/openjdk8/jvm/java-8-openjdk",
-                        "cp * /app/jre",
+                        "cp -ra * /app/jre",
                         "rm -rf /app/jre/src.zip /app/jre/include /app/jre/demo /app/jre/sample"
                     ],
                     "dest-filename": "install.sh"
@@ -176,7 +176,7 @@
                     "commands": [
                         "mkdir -p /app/jdk",
                         "cd /usr/lib/sdk/openjdk8/jvm/java-8-openjdk",
-                        "cp * /app/jdk"
+                        "cp -ra * /app/jdk"
                     ],
                     "dest-filename": "installjdk.sh"
                 },


### PR DESCRIPTION
The install scripts should copy the whole tree recursively but
the `cp` command was missing the corresponding flag.

This is already done in master but not for 18.08 but it made using the extension impossible for me without this fix.