### PR TITLE
Improve the install.sh script

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.json
+++ b/org.freedesktop.Sdk.Extension.openjdk8.json
@@ -168,9 +168,8 @@
                     "type": "script",
                     "commands": [
                         "mkdir -p /app/jre",
-                        "cd /usr/lib/sdk/openjdk8/jvm/java-8-openjdk",
-                        "cp -ra * /app/jre",
-                        "rm -rf /app/jre/src.zip /app/jre/include /app/jre/demo /app/jre/sample"
+                        "cp -ar /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/jre/{bin,lib} /app/jre",
+                        "find /app/jre -type f -name '*.diz' -delete"
                     ],
                     "dest-filename": "install.sh"
                 },


### PR DESCRIPTION
The script was copying a lot of unnecessary files (src.zip, includes, demos, samples) and deleting them afterwards. Instead, let's copy only the files required for a functional JRE.

Debugging symbols were also being copied and ended up bloating apps *tremendously*, so get rid of them as well.