### PR TITLE
manifest: set milestone to `fcs`

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -50,7 +50,7 @@ modules:
   - --with-extra-cxxflags=-O2 -g -Wno-error -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
   - --with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
   - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now
-  - --with-milestone=adoptopenjdk
+  - --with-milestone=fcs
   - --with-update-version=282
   - --with-build-number=b08
   - --with-company-name=AdoptOpenJDK


### PR DESCRIPTION
The special milestone `fcs` triggers a build without `-<milestone>`
being appended to the version output.

Fixes #11