### PR TITLE
Update 20.08 to 302-b08 & maven 3.8.3

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.appdata.xml
@@ -10,5 +10,5 @@
       This SDK extension allows you to build java apps.
     </p>
   </description>
-  <url type="homepage">https://adoptopenjdk.net</url>
+  <url type="homepage">https://adoptium.net</url>
 </component>

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -72,9 +72,9 @@ modules:
   - '*.cmd'
   sources:
   - type: file
-    url: http://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
+    url: http://archive.apache.org/dist/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz
     dest-filename: apache-maven-bin.tar.gz
-    sha512: c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+    sha512: 1c12a5df43421795054874fd54bb8b37d242949133b5bf6052a063a13a93f13a20e6e9dae2b3d85b9c7034ec977bbc2b6e7f66832182b9c863711d78bfe60faa
   build-commands:
   - mkdir -p $FLATPAK_DEST/maven
   - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -27,14 +27,14 @@ modules:
     dest: bootstrap-java
     only-arches:
     - aarch64
-    url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jdk_aarch64_linux_hotspot_8u265b01.tar.gz
-    sha256: 87d16dac293d2a9abbb559a277bfaded702f28d1bfdc526f8613bb9cfed84a12
+    url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz
+    sha256: f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551
   - type: archive
     dest: bootstrap-java
     only-arches:
     - x86_64
-    url: https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u265b01.tar.gz
-    sha256: 1285da6278f2d38a790a21148d7e683f20de0799c44b937043830ef6b57f58c4
+    url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz
+    sha256: cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a
   build-commands:
   - mv bootstrap-java $FLATPAK_DEST/
 - name: java
@@ -51,8 +51,8 @@ modules:
   - --with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
   - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now
   - --with-milestone=fcs
-  - --with-update-version=292
-  - --with-build-number=b10
+  - --with-update-version=302
+  - --with-build-number=b08
   make-args:
   - JAVAC_FLAGS=-g
   - LOG=trace
@@ -61,15 +61,8 @@ modules:
   - images
   sources:
   - type: git
-    skip-arches:
-    - aarch64
-    url: https://github.com/AdoptOpenJDK/openjdk-jdk8u.git
-    branch: jdk8u292-b10
-  - type: git
-    only-arches:
-    - aarch64
-    url: https://github.com/AdoptOpenJDK/openjdk-aarch64-jdk8u.git
-    branch: aarch64-shenandoah-jdk8u292-b10
+    url: https://github.com/adoptium/jdk8u.git
+    branch: jdk8u302-b08
   - type: shell
     commands:
     - chmod a+x configure


### PR DESCRIPTION
Update OpenJDK 8 to 302-b08 from Eclipse Adoptium. Because Adoptium doesn't use aarch64-shenandoah, aarch64 is now simply build from the main repo.

**The update was only built & tested for x86_64!**

@TingPing @MatMaul Would be great if someone could check & merge this & #13 / [branch/21.08](https://github.com/cxrvh/org.freedesktop.Sdk.Extension.openjdk8/tree/branch/21.08).