### PR TITLE
Add x-checker-data for automatic update of the modules in 23.08

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.yaml]
+max_line_length = 1000

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -50,8 +50,6 @@ modules:
       - --with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
       - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now
       - --with-milestone=fcs
-      - --with-update-version=392
-      - --with-build-number=b08
     make-args:
       - JAVAC_FLAGS=-g
       - LOG=trace
@@ -60,11 +58,18 @@ modules:
       - images
     sources:
       - type: git
-        url: 'https://github.com/adoptium/jdk8u.git'
+        url: https://github.com/adoptium/jdk8u.git
         tag: jdk8u392-b08
+        commit: 9499e54ebbab17b0f5e48be27c0c7f90806a3c40
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
+          is-main-source: true
+          tag-query: .tag_name
       - type: shell
         commands:
           - chmod a+x configure
+          - git describe --match "jdk8u*-b*" HEAD | sed -e 's/jdk8u[[:digit:]]\+-\(b[[:digit:]]\+\)/JDK_BUILD_NUMBER=\1/' >> common/autoconf/version-numbers
   - name: maven
     buildsystem: simple
     cleanup:
@@ -74,6 +79,14 @@ modules:
         url: http://archive.apache.org/dist/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
         sha512: deaa39e16b2cf20f8cd7d232a1306344f04020e1f0fb28d35492606f647a60fe729cc40d3cba33e093a17aed41bd161fe1240556d0f1b80e773abd408686217e
+        x-checker-data:
+          type: anitya
+          project-id: 1894
+          stable-only: true
+          is-main-source: false
+          url-template: http://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz
+          versions:
+            <: 4.0.0
     build-commands:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven


### PR DESCRIPTION
Remove the config-options (--with-update-version & --with-build-number) which can't be set by flatpak-external-data-checker. Instead, generate the missing build-number via a bash command & write it into common/autoconf/version-numbers to automatically pick the current version at build time. Most likely the tag format will not change in a future release.

Add .editorconfig to avoid line splitting on manifest update.