### PR TITLE
Update bootstrap-java and maven modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
 # SDK Extension for OpenJDK 8
+
+This extension contains the OpenJDK 8 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+
+OpenJDK 8 is the previous long-term support (LTS) version.
+
+For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
+
+For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
+
+## Usage
+
+You can bundle the JRE with your Flatpak application by adding this SDK extension to your Flatpak manifest and calling the install.sh script. For example:
+
+```yaml
+app-id: com.example.myapp
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk8
+command: myapp
+
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --env=PATH=/app/jre/bin:/app/bin:/usr/bin
+  - --env=JAVA_HOME=/app/jre
+  # ...
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk8/install.sh
+
+  - name: myapp
+    buildsystem: simple
+    build-options:
+      env:
+        PATH: /app/bin:/usr/bin:/usr/lib/sdk/openjdk8/bin
+        JAVA_HOME: /usr/lib/sdk/openjdk8/jvm/java-8-openjdk
+    build-commands:
+      - install -Dm755 -t /app/bin myapp
+      - install -Dm644 -t /app/share/com.example.myapp myapp.jar
+      # ...
+    sources:
+      - type: archive
+        url: https://example.com/myapp/download/myapp-1.0.0.tar.gz
+        # ...
+      - type: script
+        dest-filename: myapp
+        commands:
+          - exec java -jar /app/share/com.example.myapp/myapp.jar $@
+      # ...
+```

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -25,9 +25,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_aarch64_linux_hotspot_8u382b05.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_aarch64_linux_hotspot_8u422b05.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 0951398197b7bef39ab987b59c22852812ee2c2da6549953eed7fced4c08e13d
+        sha256: af98a839ec238106078bd360af9e405dc6665c05ee837178ed13b92193681923
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -37,9 +37,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u422-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u422b05.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 789ad24dc0d9618294e3ba564c9bfda9d3f3a218604350e0ce0381bbc8f28db3
+        sha256: 4c6056f6167fae73ace7c3080b78940be5c87d54f5b08894b3517eed1cbb2c06
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -88,9 +88,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.8/binaries/apache-maven-3.9.8-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 7d171def9b85846bf757a2cec94b7529371068a0670df14682447224e57983528e97a6d1b850327e4ca02b139abaab7fcb93c4315119e6f0ffb3f0cbc0d0b9a2
+        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
         x-checker-data:
           type: anitya
           project-id: 1894

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -26,13 +26,25 @@ modules:
         only-arches:
           - aarch64
         url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_aarch64_linux_hotspot_8u382b05.tar.gz
+        dest-filename: java-openjdk.tar.gz
         sha256: 0951398197b7bef39ab987b59c22852812ee2c2da6549953eed7fced4c08e13d
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name | startswith("OpenJDK8U-jdk_aarch64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
       - type: archive
         dest: bootstrap-java
         only-arches:
           - x86_64
         url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz
+        dest-filename: java-openjdk.tar.gz
         sha256: 789ad24dc0d9618294e3ba564c9bfda9d3f3a218604350e0ce0381bbc8f28db3
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name | startswith("OpenJDK8U-jdk_x64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
     build-commands:
       - mv bootstrap-java $FLATPAK_DEST/
   - name: java


### PR DESCRIPTION
- bootstrap-java: Update java-openjdk.tar.gz to jdk8u422-b05
- maven: Update apache-maven-bin.tar.gz to 3.9.9

This also adds some basic information to the README, plus [`x-checker-data`](https://github.com/flathub-infra/flatpak-external-data-checker) information to keep the JDK up to date.

Closes #49