### PR TITLE
[branch/23.08] Update bootstrap-java and java modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -25,9 +25,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u432-b06/OpenJDK8U-jdk_aarch64_linux_hotspot_8u432b06.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_aarch64_linux_hotspot_8u442b06.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 383caabc20428e9500f2e07965317ed4387a0e336104483e29a9e06eeffbf26b
+        sha256: 1d1662bd8ca7edc9281c723d9eebafea940e6a41464bdc43a83b564bc974c7e5
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -37,9 +37,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u432-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u432b06.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: abaaa90deadf51bd28921453baf2992b3dff6171bb7142f5bdd14ef269f7b245
+        sha256: 5b0a0145e7790552a9c8767b4680074c4628ec276e5bb278b61d85cf90facafa
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -71,8 +71,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk8u.git
-        tag: jdk8u432-b06
-        commit: 618917eb093243de2c5d7e83d4688bfe9ad04985
+        tag: jdk8u442-b06
+        commit: 129290d2ffe3f77ad574bfad8b1ab44f5f3b8fbe
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest


### PR DESCRIPTION
bootstrap-java: Update java-openjdk.tar.gz to jdk8u442-b06
java: Update jdk8u.git

(cherry picked from commit bf1429f3cd5e8d9e2e6369224309c3ccb6ae7777)