### PR TITLE
[branch/23.08] Patch: ConfigureNotify behavior has changed in KWin 6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+builddir
+repo

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -78,6 +78,9 @@ modules:
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
           is-main-source: true
           tag-query: .tag_name
+      - type: patch
+        paths:
+          - patches/0001-ConfigureNotify-behavior-has-changed-in-KWin-6.2.patch
       - type: shell
         commands:
           - chmod a+x configure

--- a/patches/0001-ConfigureNotify-behavior-has-changed-in-KWin-6.2.patch
+++ b/patches/0001-ConfigureNotify-behavior-has-changed-in-KWin-6.2.patch
@@ -1,0 +1,43 @@
+From ba416bdccba6b9f9384c83bf6414a9f953a98ab3 Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Tue, 15 Jul 2025 11:09:19 -0300
+Subject: [PATCH] ConfigureNotify behavior has changed in KWin 6.2
+
+This fixes incorrectly positioned and disappearing context menus in KWin
+6.2+. This should not negatively impact older KWin versions.
+
+This fix was tested on Plasma versions 5.27.5 and 6.4.2, on both X11 and
+Wayland (through XWayland) sessions, by running Arduino IDE 1.8.19
+(built with Java 8), and then verifying that the behavior of drop down
+menus is correct and consistent in both Plasma versions.
+
+Steps taken:
+
+1. Open Arduino IDE
+2. Maximize the window
+3. Left click on the "File" menu
+4. Verify that the menu created is positioned correctly
+5. Verify that the menu created does not disappear when you release the
+   left mouse button
+
+Bug: https://bugs.openjdk.org/browse/JDK-8338751
+Backport-of: https://github.com/openjdk/jdk/commit/3da68900818fc43b777098fe6e244779794d5294
+---
+ jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java b/jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java
+index b45277355d..469b60a7d2 100644
+--- a/jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java
++++ b/jdk/src/solaris/classes/sun/awt/X11/XWindowPeer.java
+@@ -771,6 +771,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
+             // TODO this should be the default for every case.
+             switch (runningWM) {
+                 case XWM.CDE_WM:
++                case XWM.KDE2_WM:
+                 case XWM.MOTIF_WM:
+                 case XWM.METACITY_WM:
+                 case XWM.MUTTER_WM:
+-- 
+2.50.1
+


### PR DESCRIPTION
This fixes incorrectly positioned and disappearing context menus in KWin 6.2+. This should not negatively impact older KWin versions.

This fix was tested on Plasma versions 5.27.5 and 6.4.2, on both X11 and Wayland (through XWayland) sessions, by running [Arduino IDE](https://github.com/flathub/cc.arduino.arduinoide) 1.8.19 (built with Java 8), and then verifying that the behavior of drop down menus is correct and consistent in both Plasma versions.

Steps taken:

1\. Open Arduino IDE
2\. Maximize the window
3\. Left click on the "File" menu
4\. Verify that the menu created is positioned correctly
5\. Verify that the menu created does not disappear when you release the left mouse button

Bug: https://bugs.openjdk.org/browse/JDK-8338751
Backport-of: https://github.com/openjdk/jdk/commit/3da68900818fc43b777098fe6e244779794d5294

(cherry picked from commit 8f9745e87f7b9b5b3e640fc687e342160eb58910)