### PR TITLE
[branch/23.08] Update bootstrap-java, java and maven modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -25,9 +25,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u452b09.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u462b08.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: d8a1aecea0913b7a1e0d737ba6f7ea99059b3f6fd17813d4a24e8b3fc3aee278
+        sha256: 19552c1cf7f5c18290a6bdcd6757f70ea5c331a2bc0dd7a3b3120e8dbc4b4891
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -37,9 +37,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 9448308a21841960a591b47927cf2d44fdc4c0533a5f8111a4b243a6bafb5d27
+        sha256: 5d64ae542b59a962b3caadadd346f4b1c3010879a28bb02d928326993de16e79
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -71,8 +71,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk8u.git
-        tag: jdk8u452-b09
-        commit: 35c254f58c70663df28cc7d15c9545c88250b6ce
+        tag: jdk8u462-b08
+        commit: 943a5ea328fd2fc8eed0aed4ec9b1957d41f8144
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -91,9 +91,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
         x-checker-data:
           type: anitya
           project-id: 1894


### PR DESCRIPTION
bootstrap-java: Update java-openjdk.tar.gz to jdk8u462-b08
java: Update jdk8u.git
maven: Update apache-maven-bin.tar.gz to 3.9.11

(cherry picked from commit 744117ec8d6480c7fef8ecc19b1df32ea2c57bcf)