### PR TITLE
[branch/25.08] Update runtime to 25.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can bundle the JRE with your Flatpak application by adding this SDK extensio
 ```yaml
 app-id: com.example.myapp
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk8

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -1,7 +1,7 @@
 id: org.freedesktop.Sdk.Extension.openjdk8
-branch: '24.08'
+branch: '25.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '24.08'
+runtime-version: '25.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
@@ -58,7 +58,7 @@ modules:
       - --with-zlib=system
       - --with-giflib=system
       - --with-extra-cxxflags=-O2 -g -Wno-error -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
-      - --with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
+      - --with-extra-cflags=-O2 -g -std=gnu99 -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fcommon
       - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now
       - --with-milestone=fcs
     make-args:
@@ -82,6 +82,7 @@ modules:
           - patches/0001-Fix-Wint-conversion.patch
           - patches/0002-Fix-Wincompatible-pointer-types.patch
           - patches/0003-ConfigureNotify-behavior-has-changed-in-KWin-6.2.patch
+          - patches/0004-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
       - type: shell
         commands:
           - chmod a+x configure

--- a/patches/0004-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
+++ b/patches/0004-Build-failure-with-glibc-2.42-due-to-uabs-name.patch
@@ -1,0 +1,134 @@
+From 9151ab405d463769d541684596d5b3789f0898b7 Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Wed, 3 Sep 2025 18:09:28 -0300
+Subject: [PATCH] Build failure with glibc 2.42 due to uabs() name collision
+
+Backport of: https://github.com/adoptium/jdk/commit/38bb8adf4f632b08af15f2d8530b35f05f86a020
+---
+ hotspot/src/cpu/aarch64/vm/assembler_aarch64.cpp      | 2 +-
+ hotspot/src/cpu/aarch64/vm/assembler_aarch64.hpp      | 2 +-
+ hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp | 2 +-
+ hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp  | 4 ++--
+ hotspot/src/share/vm/opto/mulnode.cpp                 | 4 ++--
+ hotspot/src/share/vm/utilities/globalDefinitions.hpp  | 8 ++++----
+ 6 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/hotspot/src/cpu/aarch64/vm/assembler_aarch64.cpp b/hotspot/src/cpu/aarch64/vm/assembler_aarch64.cpp
+index 7972d3a3fb..1fba39a30f 100644
+--- a/hotspot/src/cpu/aarch64/vm/assembler_aarch64.cpp
++++ b/hotspot/src/cpu/aarch64/vm/assembler_aarch64.cpp
+@@ -1445,7 +1445,7 @@ void Assembler::add_sub_immediate(Register Rd, Register Rn, unsigned uimm, int o
+ 
+ bool Assembler::operand_valid_for_add_sub_immediate(long imm) {
+   bool shift = false;
+-  unsigned long uimm = uabs(imm);
++  unsigned long uimm = g_uabs(imm);
+   if (uimm < (1 << 12))
+     return true;
+   if (uimm < (1 << 24)
+diff --git a/hotspot/src/cpu/aarch64/vm/assembler_aarch64.hpp b/hotspot/src/cpu/aarch64/vm/assembler_aarch64.hpp
+index 995f524b45..0320f91490 100644
+--- a/hotspot/src/cpu/aarch64/vm/assembler_aarch64.hpp
++++ b/hotspot/src/cpu/aarch64/vm/assembler_aarch64.hpp
+@@ -825,7 +825,7 @@ public:
+   static const unsigned long branch_range = NOT_DEBUG(128 * M) DEBUG_ONLY(2 * M);
+ 
+   static bool reachable_from_branch_at(address branch, address target) {
+-    return uabs(target - branch) < branch_range;
++    return g_uabs(target - branch) < branch_range;
+   }
+ 
+   // Unconditional branch (immediate)
+diff --git a/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp b/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
+index 425c4ceca7..4725e16c49 100644
+--- a/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
++++ b/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
+@@ -2023,7 +2023,7 @@ void MacroAssembler::wrap_add_sub_imm_insn(Register Rd, Register Rn, unsigned im
+   if (operand_valid_for_add_sub_immediate((int)imm)) {
+     (this->*insn1)(Rd, Rn, imm);
+   } else {
+-    if (uabs(imm) < (1 << 24)) {
++    if (g_uabs(imm) < (1 << 24)) {
+        (this->*insn1)(Rd, Rn, imm & -(1 << 12));
+        (this->*insn1)(Rd, Rd, imm & ((1 << 12)-1));
+     } else {
+diff --git a/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp b/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
+index dc04f4841b..411517ac76 100644
+--- a/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
++++ b/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
+@@ -1093,7 +1093,7 @@ class StubGenerator: public StubCodeGenerator {
+ 
+   void copy_memory_small(Register s, Register d, Register count, Register tmp, int step) {
+     bool is_backwards = step < 0;
+-    size_t granularity = uabs(step);
++    size_t granularity = g_uabs(step);
+     int direction = is_backwards ? -1 : 1;
+     int unit = wordSize * direction;
+ 
+@@ -1149,7 +1149,7 @@ class StubGenerator: public StubCodeGenerator {
+                    Register count, Register tmp, int step) {
+     copy_direction direction = step < 0 ? copy_backwards : copy_forwards;
+     bool is_backwards = step < 0;
+-    int granularity = uabs(step);
++    int granularity = g_uabs(step);
+     const Register t0 = r3, t1 = r4;
+ 
+     // <= 96 bytes do inline. Direction doesn't matter because we always
+diff --git a/hotspot/src/share/vm/opto/mulnode.cpp b/hotspot/src/share/vm/opto/mulnode.cpp
+index 9f2a134f1e..c641215e6e 100644
+--- a/hotspot/src/share/vm/opto/mulnode.cpp
++++ b/hotspot/src/share/vm/opto/mulnode.cpp
+@@ -189,7 +189,7 @@ Node *MulINode::Ideal(PhaseGVN *phase, bool can_reshape) {
+   // Check for negative constant; if so negate the final result
+   bool sign_flip = false;
+ 
+-  unsigned int abs_con = uabs(con);
++  unsigned int abs_con = g_uabs(con);
+   if (abs_con != (unsigned int)con) {
+     sign_flip = true;
+   }
+@@ -285,7 +285,7 @@ Node *MulLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
+ 
+   // Check for negative constant; if so negate the final result
+   bool sign_flip = false;
+-  julong abs_con = uabs(con);
++  julong abs_con = g_uabs(con);
+   if (abs_con != (julong)con) {
+     sign_flip = true;
+   }
+diff --git a/hotspot/src/share/vm/utilities/globalDefinitions.hpp b/hotspot/src/share/vm/utilities/globalDefinitions.hpp
+index 4207777aee..a9b58b04db 100644
+--- a/hotspot/src/share/vm/utilities/globalDefinitions.hpp
++++ b/hotspot/src/share/vm/utilities/globalDefinitions.hpp
+@@ -1254,7 +1254,7 @@ inline bool is_even(intx x) { return !is_odd(x); }
+ 
+ // abs methods which cannot overflow and so are well-defined across
+ // the entire domain of integer types.
+-static inline unsigned int uabs(unsigned int n) {
++static inline unsigned int g_uabs(unsigned int n) {
+   union {
+     unsigned int result;
+     int value;
+@@ -1263,7 +1263,7 @@ static inline unsigned int uabs(unsigned int n) {
+   if (value < 0) result = 0-result;
+   return result;
+ }
+-static inline julong uabs(julong n) {
++static inline julong g_uabs(julong n) {
+   union {
+     julong result;
+     jlong value;
+@@ -1272,8 +1272,8 @@ static inline julong uabs(julong n) {
+   if (value < 0) result = 0-result;
+   return result;
+ }
+-static inline julong uabs(jlong n) { return uabs((julong)n); }
+-static inline unsigned int uabs(int n) { return uabs((unsigned int)n); }
++static inline julong g_uabs(jlong n) { return g_uabs((julong)n); }
++static inline unsigned int g_uabs(int n) { return g_uabs((unsigned int)n); }
+ 
+ // "to" should be greater than "from."
+ inline intx byte_size(void* from, void* to) {
+-- 
+2.51.0
+


### PR DESCRIPTION
This imports an [upstream patch](https://github.com/adoptium/jdk/commit/38bb8adf4f632b08af15f2d8530b35f05f86a020) (backported) to fix a build failure with glibc >= 2.42:

```
/run/build/java/hotspot/src/share/vm/utilities/globalDefinitions.hpp:1276:28: error: ‘unsigned int uabs(int)’ was declared ‘extern’ and later ‘static’ [-fpermissive]
 1276 | static inline unsigned int uabs(int n) { return uabs((unsigned int)n); }
      |                            ^~~~
In file included from /usr/include/c++/15.2.0/cstdlib:83,
                 from /usr/include/c++/15.2.0/stdlib.h:36,
                 from /run/build/java/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp:39,
                 from /run/build/java/hotspot/src/share/vm/utilities/globalDefinitions.hpp:38:
/usr/include/stdlib.h:989:21: note: previous declaration of ‘unsigned int uabs(int)’
  989 | extern unsigned int uabs (int __x) __THROW __attribute__ ((__const__)) __wur;
      |                     ^~~~
```

This also adds a build flag to set the C standard to GNU99, to fix yet another build failure:

```
/run/build/java/hotspot/agent/src/os/linux/libproc.h:86:13: error: ‘bool’ cannot be defined via ‘typedef’
   86 | typedef int bool;
      |             ^~~~
/run/build/java/hotspot/agent/src/os/linux/libproc.h:86:13: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
```