### PR TITLE
[branch/24.08] Update bootstrap-java and java modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -24,9 +24,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u462b08.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u472b08.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 19552c1cf7f5c18290a6bdcd6757f70ea5c331a2bc0dd7a3b3120e8dbc4b4891
+        sha256: e2aff19d85d2441e409d6cbdf12ef7c2acabb0de73bca4207947135dcaa935a2
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -36,9 +36,9 @@ modules:
         dest: bootstrap-java
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
+        url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u472b08.tar.gz
         dest-filename: java-openjdk.tar.gz
-        sha256: 5d64ae542b59a962b3caadadd346f4b1c3010879a28bb02d928326993de16e79
+        sha256: 5becaa4ac660e844c5a39e2ebc39ff5ac824c37ff1b625af8c8b111dc13c3592
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk8u.git
-        tag: jdk8u462-b08
-        commit: 943a5ea328fd2fc8eed0aed4ec9b1957d41f8144
+        tag: jdk8u472-b08
+        commit: d5ac2ad89a369697a48e7f3e6b889e22afa50a2f
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest


### PR DESCRIPTION
bootstrap-java: Update java-openjdk.tar.gz to jdk8u472-b08
java: Update jdk8u.git

(cherry picked from commit 26784cbededf4b67e8e7b3d569105b669a4b2ff8)