### PR TITLE
[branch/24.08] Update java and maven modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This extension contains the OpenJDK 8 Java Runtime Environment (JRE) and Java De
 
 OpenJDK 8 is the previous long-term support (LTS) version.
 
-For the current LTS version, see the [OpenJDK 21](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21) extension.
+For the current LTS version, see the [OpenJDK 25](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk25) extension.
 
 For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
 

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "skip-arches": ["arm"],
     "skip-icons-check": "true"
 }

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -31,11 +31,6 @@ modules:
         url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u472b08.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: e2aff19d85d2441e409d6cbdf12ef7c2acabb0de73bca4207947135dcaa935a2
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name | startswith("OpenJDK8U-jdk_aarch64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
       - type: archive
         dest: bootstrap-java
         only-arches:
@@ -43,11 +38,6 @@ modules:
         url: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u472-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u472b08.tar.gz
         dest-filename: java-openjdk.tar.gz
         sha256: 5becaa4ac660e844c5a39e2ebc39ff5ac824c37ff1b625af8c8b111dc13c3592
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
-          version-query: .tag_name
-          url-query: .assets[] | select(.name | startswith("OpenJDK8U-jdk_x64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
     build-commands:
       - mv bootstrap-java $FLATPAK_DEST/
 

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -65,8 +65,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/adoptium/jdk8u.git
-        tag: jdk8u472-b08
-        commit: d5ac2ad89a369697a48e7f3e6b889e22afa50a2f
+        tag: jdk8u482-b08
+        commit: cea3cd4c1d7aa70e998d45ca2e419793a550321e
         x-checker-data:
           type: json
           url: https://api.github.com/repos/adoptium/temurin8-binaries/releases/latest
@@ -89,9 +89,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
+        sha512: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
         x-checker-data:
           type: anitya
           project-id: 1894

--- a/org.freedesktop.Sdk.Extension.openjdk8.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk8.yaml
@@ -5,16 +5,20 @@ runtime-version: '24.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
+
 cleanup:
   - /share/info
   - /share/man
+
 build-options:
   no-debuginfo: true
   strip: true
   prefix: /usr/lib/sdk/openjdk8
   env:
     V: '1'
+
 modules:
+  # Boot JDK requirements: https://htmlpreview.github.io/?https://raw.githubusercontent.com/openjdk/jdk/master/doc/building.html#boot-jdk-requirements
   - name: bootstrap-java
     cleanup:
       - '*'
@@ -46,6 +50,7 @@ modules:
           url-query: .assets[] | select(.name | startswith("OpenJDK8U-jdk_x64_linux_hotspot_") and endswith(".tar.gz")).browser_download_url
     build-commands:
       - mv bootstrap-java $FLATPAK_DEST/
+
   - name: java
     buildsystem: autotools
     no-parallel-make: true
@@ -86,6 +91,8 @@ modules:
         commands:
           - chmod a+x configure
           - git describe --match "jdk8u*-b*" HEAD | sed -e 's/jdk8u[[:digit:]]\+-\(b[[:digit:]]\+\)/JDK_BUILD_NUMBER=\1/' >> common/autoconf/version-numbers
+
+  # Java version requirements for Maven: https://maven.apache.org/docs/history.html
   - name: maven
     buildsystem: simple
     cleanup:
@@ -107,6 +114,7 @@ modules:
       - mkdir -p $FLATPAK_DEST/maven
       - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven
       - ln -s $FLATPAK_DEST/maven/bin/mvn $FLATPAK_DEST/maven/bin/mvnDebug $FLATPAK_DEST/bin
+
   - name: scripts
     buildsystem: simple
     sources:
@@ -131,6 +139,7 @@ modules:
     build-commands:
       - (cd /usr/lib/sdk/openjdk8/jvm && ln -s openjdk-1.8.0* java-8-openjdk)
       - cp enable.sh install.sh installjdk.sh /usr/lib/sdk/openjdk8/
+
   - name: appdata
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Changes:

- No need to skip arm
- readme: OpenJDK 25 is the current LTS version
- manifest: Add some useful documentation links
- Remove f-e-d-c for Boot JDK
- java: Update jdk8u.git to jdk8u482-b08
- maven: Update apache-maven-bin.tar.gz to 3.9.12